### PR TITLE
remove one inline, fix one typo

### DIFF
--- a/ql/math/matrixutilities/pseudosqrt.hpp
+++ b/ql/math/matrixutilities/pseudosqrt.hpp
@@ -132,7 +132,7 @@ namespace QuantLib {
         }
 
         //cost function for hypersphere and lower-diagonal algorithm
-        inline class HypersphereCostFunction : public CostFunction {
+        class HypersphereCostFunction : public CostFunction {
           private:
             Size size_;
             bool lowerDiagonal_;

--- a/ql/math/optimization/constraint.hpp
+++ b/ql/math/optimization/constraint.hpp
@@ -224,7 +224,7 @@ namespace QuantLib {
     inline Constraint::Constraint(const boost::shared_ptr<Constraint::Impl>& impl)
     : impl_(impl) {}
 
-    inlien Real Constraint::update(Array& params,
+    inline Real Constraint::update(Array& params,
                             const Array& direction,
                             Real beta) {
 


### PR DESCRIPTION
Two simple things which `g++-6.2` brought up.