### PR TITLE
Enable Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 dist: trusty
 
 before_install:
-  # empty -- no other packages needed
+  - sudo apt-get install libboost-all-dev
 
 install:
   # empty -- all headers

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   # empty -- all headers
 
 script:
-  - cd test-suite && g++ -I.. -o quantlibtestsuite quantlibtestsuite.cpp && ./quantlibtestsuite --log-level=message
+  - cd test-suite && g++ -I.. -o quantlibtestsuite quantlibtestsuite.cpp && ./quantlibtestsuite --log_level=message
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+
+language: cpp
+
+sudo: required
+
+dist: trusty
+
+before_install:
+  # empty -- no other packages needed
+
+install:
+  # empty -- all headers
+
+script:
+  - cd test-suite && g++ -I.. -o quantlibtestsuite quantlibtestsuite.cpp && ./quantlibtestsuite --log-level=message
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+  


### PR DESCRIPTION
You may need to 'turn on' Travis for your account as well as the repo.  Then, once this `.travis.yml` is added builds will be triggered on each commit.    

My log of builds is [here](https://travis-ci.org/eddelbuettel/Quantuccia) with an initial fail when I had builds already turned on, pushed your changes (sans `.travis.yml`) which failed and then an initial failure when I had not yet installed Boost.   The third worked, but misspelled log_level as log-level so I will run another in a second.